### PR TITLE
libvirt: Don't duplicate default variables

### DIFF
--- a/libvirt/module/variables.tf
+++ b/libvirt/module/variables.tf
@@ -15,26 +15,31 @@ variable "cidr_subnet" {
 }
 
 variable "machines" {
-  type    = number
-  default = 1
+  type     = number
+  nullable = false
+  default  = 1
 }
 
 variable "vcpus" {
-  type    = number
-  default = 2
+  type     = number
+  nullable = false
+  default  = 2
 }
 
 variable "memory" {
-  type    = number
-  default = 8192
+  type     = number
+  nullable = false
+  default  = 8192
 }
 
 variable "extra_disks" {
-  type    = number
-  default = 0
+  type     = number
+  nullable = false
+  default  = 0
 }
 
 variable "extra_disk_size" {
-  type    = number
-  default = 20
+  type     = number
+  nullable = false
+  default  = 20
 }

--- a/libvirt/variables.tf
+++ b/libvirt/variables.tf
@@ -15,28 +15,26 @@ variable "cidr_subnet" {
 }
 
 variable "machines" {
-  type = number
-  # This should be changed to null when Terraform v1.1.0 is released:
-  # https://github.com/hashicorp/terraform/blob/16800d1305f3b9035095683e5cdeb64ea286f845/website/docs/language/values/variables.html.md#disallowing-null-module-input-values
-  default = 1
+  type    = number
+  default = null
 }
 
 variable "vcpus" {
   type    = number
-  default = 2
+  default = null
 }
 
 variable "memory" {
   type    = number
-  default = 8192
+  default = null
 }
 
 variable "extra_disks" {
   type    = number
-  default = 0
+  default = null
 }
 
 variable "extra_disk_size" {
   type    = number
-  default = 20
+  default = null
 }


### PR DESCRIPTION
We can avoid this with the new nullable argument[1] in Terraform v1.1.0.

[1] https://www.terraform.io/docs/language/values/variables.html#disallowing-null-input-values